### PR TITLE
add x button for closing a panel

### DIFF
--- a/packages/studio-base/src/components/PanelToolbar/PanelActionsDropdown.tsx
+++ b/packages/studio-base/src/components/PanelToolbar/PanelActionsDropdown.tsx
@@ -30,7 +30,6 @@ type Props = {
 };
 
 const useStyles = makeStyles()((theme) => ({
-  error: { color: theme.palette.error.main },
   icon: {
     marginRight: theme.spacing(-1),
   },

--- a/packages/studio-base/src/components/PanelToolbar/PanelToolbarControls.tsx
+++ b/packages/studio-base/src/components/PanelToolbar/PanelToolbarControls.tsx
@@ -11,21 +11,24 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import SettingsIcon from "@mui/icons-material/Settings";
 import CloseIcon from "@mui/icons-material/Close";
+import SettingsIcon from "@mui/icons-material/Settings";
 import { forwardRef, useCallback, useContext, useMemo } from "react";
 import { MosaicContext, MosaicNode, MosaicWindowContext } from "react-mosaic-component";
+
 import PanelContext from "@foxglove/studio-base/components/PanelContext";
 import ToolbarIconButton from "@foxglove/studio-base/components/PanelToolbar/ToolbarIconButton";
 import Stack from "@foxglove/studio-base/components/Stack";
-import { useSelectedPanels } from "@foxglove/studio-base/context/CurrentLayoutContext";
+import {
+  useSelectedPanels,
+  useCurrentLayoutActions,
+} from "@foxglove/studio-base/context/CurrentLayoutContext";
 import PanelCatalogContext from "@foxglove/studio-base/context/PanelCatalogContext";
 import {
   PanelStateStore,
   usePanelStateStore,
 } from "@foxglove/studio-base/context/PanelStateContext";
 import { useWorkspaceActions } from "@foxglove/studio-base/context/Workspace/useWorkspaceActions";
-import { useCurrentLayoutActions } from "@foxglove/studio-base/context/CurrentLayoutContext";
 
 import { PanelActionsDropdown } from "./PanelActionsDropdown";
 

--- a/packages/studio-base/src/components/PanelToolbar/PanelToolbarControls.tsx
+++ b/packages/studio-base/src/components/PanelToolbar/PanelToolbarControls.tsx
@@ -12,8 +12,9 @@
 //   You may not use this file except in compliance with the License.
 
 import SettingsIcon from "@mui/icons-material/Settings";
+import CloseIcon from "@mui/icons-material/Close";
 import { forwardRef, useCallback, useContext, useMemo } from "react";
-
+import { MosaicContext, MosaicNode, MosaicWindowContext } from "react-mosaic-component";
 import PanelContext from "@foxglove/studio-base/components/PanelContext";
 import ToolbarIconButton from "@foxglove/studio-base/components/PanelToolbar/ToolbarIconButton";
 import Stack from "@foxglove/studio-base/components/Stack";
@@ -24,6 +25,7 @@ import {
   usePanelStateStore,
 } from "@foxglove/studio-base/context/PanelStateContext";
 import { useWorkspaceActions } from "@foxglove/studio-base/context/Workspace/useWorkspaceActions";
+import { useCurrentLayoutActions } from "@foxglove/studio-base/context/CurrentLayoutContext";
 
 import { PanelActionsDropdown } from "./PanelActionsDropdown";
 
@@ -59,6 +61,20 @@ const PanelToolbarControlsComponent = forwardRef<HTMLDivElement, PanelToolbarCon
       }
     }, [panelId, setSelectedPanelIds, openPanelSettings]);
 
+    const panelContext = useContext(PanelContext);
+    const tabId = panelContext?.tabId;
+    const { mosaicActions } = useContext(MosaicContext);
+    const { mosaicWindowActions } = useContext(MosaicWindowContext);
+    const { closePanel } = useCurrentLayoutActions();
+
+    const close = useCallback(() => {
+      closePanel({
+        tabId,
+        root: mosaicActions.getRoot() as MosaicNode<string>,
+        path: mosaicWindowActions.getPath(),
+      });
+    }, [closePanel, mosaicActions, mosaicWindowActions, tabId]);
+
     // Show the settings button so that panel title is editable, unless we have a custom
     // toolbar in which case the title wouldn't be visible.
     const showSettingsButton = panelInfo?.hasCustomToolbar !== true || hasSettings;
@@ -72,6 +88,9 @@ const PanelToolbarControlsComponent = forwardRef<HTMLDivElement, PanelToolbarCon
           </ToolbarIconButton>
         )}
         <PanelActionsDropdown isUnknownPanel={isUnknownPanel} />
+        <ToolbarIconButton title="Close" onClick={close}>
+          <CloseIcon />
+        </ToolbarIconButton>
       </Stack>
     );
   },


### PR DESCRIPTION
**User-Facing Changes**
<!-- will be used as a changelog entry -->

**Description**
This PR removes the "Remove Panel" button from the dropdown list when clicking the settings button of a panel, and instead adds an x button right next to it. This shall make closing a panel easier.

![Screenshot 2024-07-16 133438](https://github.com/user-attachments/assets/e979d419-7caf-4d71-83f2-39a37f9d0358)

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->

**Checklist**

- [x] The web version was tested and it is running ok
- [x] The desktop version was tested and it is running ok
- [ ] I've updated/created the storybook file(s)
- [ ] The release version was updated on package.json files
