### PR TITLE
Rename application

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing Guidelines
 
-Welcome, and thank you for your interest in contributing to Foxbox! We value your contributions and want to make the contributing experience enjoyable and rewarding for you. Here’s how you can get started:
+Welcome, and thank you for your interest in contributing to Lichtblick! We value your contributions and want to make the contributing experience enjoyable and rewarding for you. Here’s how you can get started:
 
 ## :rocket: Getting Started
 
@@ -70,7 +70,7 @@ BUILD NUMBER (Optional): Optionally, the build number can be additionally added.
 
 ## :globe_with_meridians: Localization
 
-At this time, first-class support for Foxbox is provided in English only. Localization into other languages is available on a best-effort basis, with translations provided by community volunteers.
+At this time, first-class support for Lichtblick is provided in English only. Localization into other languages is available on a best-effort basis, with translations provided by community volunteers.
 
 Translation support is implemented using [`react-i18next`](https://react.i18next.com).
 
@@ -81,7 +81,7 @@ Translation support is implemented using [`react-i18next`](https://react.i18next
 
 ### Add translations to the `i18n` directory
 
-The [`i18n` directory](packages/studio-base/src/i18n) contains translated (localized) strings for all languages supported by Foxbox.
+The [`i18n` directory](packages/studio-base/src/i18n) contains translated (localized) strings for all languages supported by Lichtblick.
 
 Translated strings are organized into _namespaces_ — e.g. [`i18n/[language]/appSettings.ts`](packages/studio-base/src/i18n/en/appSettings.ts) contains translations for the app's Settings tab.
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,11 +17,11 @@ EXPOSE 8080
 
 COPY <<EOF /entrypoint.sh
 # Optionally override the default layout with one provided via bind mount
-mkdir -p /foxbox
-touch /foxbox/default-layout.json
+mkdir -p /lichtblick
+touch /lichtblick/default-layout.json
 index_html=\$(cat index.html)
 replace_pattern='/*FOXBOX_STUDIO_DEFAULT_LAYOUT_PLACEHOLDER*/'
-replace_value=\$(cat /foxbox/default-layout.json)
+replace_value=\$(cat /lichtblick/default-layout.json)
 echo "\${index_html/"\$replace_pattern"/\$replace_value}" > index.html
 
 # Continue executing the CMD

--- a/README.md
+++ b/README.md
@@ -1,20 +1,20 @@
-<h1 align="center">Foxbox</h1>
+<h1 align="center">Lichtblick</h1>
 
 <div align="center">
-  <a href="https://github.com/bmw-software-engineering/foxbox/stargazers"><img src="https://img.shields.io/github/stars/bmw-software-engineering/foxbox" alt="Stars Badge"/></a>
-  <a href="https://github.com/bmw-software-engineering/foxbox/network/members"><img src="https://img.shields.io/github/forks/bmw-software-engineering/foxbox" alt="Forks Badge"/></a>
-  <a href="https://github.com/bmw-software-engineering/foxbox/pulls"><img src="https://img.shields.io/github/issues-pr/bmw-software-engineering/foxbox" alt="Pull Requests Badge"/></a>
-  <a href="https://github.com/bmw-software-engineering/foxbox/issues"><img src="https://img.shields.io/github/issues/bmw-software-engineering/foxbox" alt="Issues Badge"/></a>
-  <a href="https://github.com/bmw-software-engineering/foxbox/issues"><img src="https://img.shields.io/github/issues/bmw-software-engineering/foxbox" alt="Version"/></a>
-  <a href="https://github.com/bmw-software-engineering/foxbox/graphs/contributors"><img alt="GitHub contributors" src="https://img.shields.io/github/contributors/bmw-software-engineering/foxbox?color=2b9348"></a>
-  <a href="https://github.com/bmw-software-engineering/foxbox/blob/master/LICENSE"><img src="https://img.shields.io/github/license/bmw-software-engineering/foxbox?color=2b9348" alt="License Badge"/></a>
+  <a href="https://github.com/bmw-software-engineering/lichtblick/stargazers"><img src="https://img.shields.io/github/stars/bmw-software-engineerlichtblickxbox" alt="Stars Badge"/></a>
+  <a href="https://github.com/bmw-software-engineering/lichtblick/network/members"><img src="https://img.shields.io/github/forks/bmw-software-engineerlichtblickxbox" alt="Forks Badge"/></a>
+  <a href="https://github.com/bmw-software-engineering/lichtblick/pulls"><img src="https://img.shields.io/github/issues-pr/bmw-software-engineerlichtblickxbox" alt="Pull Requests Badge"/></a>
+  <a href="https://github.com/bmw-software-engineering/lichtblick/issues"><img src="https://img.shields.io/github/issues/bmw-software-engineerlichtblickxbox" alt="Issues Badge"/></a>
+  <a href="https://github.com/bmw-software-engineering/lichtblick/issues"><img src="https://img.shields.io/github/issues/bmw-software-engineerlichtblickxbox" alt="Version"/></a>
+  <a href="https://github.com/bmw-software-engineering/lichtblick/graphs/contributors"><img alt="GitHub contributors" src="https://img.shields.io/github/contributors/bmw-software-engineerlichtblickxbox?color=2b9348"></a>
+  <a href="https://github.com/bmw-software-engineering/lichtblick/blob/master/LICENSE"><img src="https://img.shields.io/github/license/bmw-software-engineerlichtblickxbox?color=2b9348" alt="License Badge"/></a>
 
   <br />
 <p  align="center">
-Foxbox is an integrated visualization and diagnosis tool for robotics, available in your browser or as a desktop app on Linux, Windows, and macOS.
+Lichtblick is an integrated visualization and diagnosis tool for robotics, available in your browser or as a desktop app on Linux, Windows, and macOS.
 </p>
   <p align="center">
-    <img alt="Foxbox screenshot" src="resources/screenshot.png">
+    <img alt="Lichtblick screenshot" src="resources/screenshot.png">
   </p>
 </div>
 
@@ -30,7 +30,7 @@ Foxbox is an integrated visualization and diagnosis tool for robotics, available
 Clone the repository:
 
 ```sh
-$ git clone https://github.com/bmw-software-engineering/foxbox.git
+$ git clone https://github.com/bmw-software-engineering/lichtblick.git
 ```
 
 Pull large files with Git LFS:
@@ -64,7 +64,7 @@ $ yarn desktop:start        # launch electron
 $ yarn run web:serve        # it will be avaiable in http://localhost:8080
 ```
 
-## :hammer_and_wrench: Building Foxbox
+## :hammer_and_wrench: Building Lichtblick
 
 Build the application for production using these commands:
 
@@ -80,8 +80,8 @@ $ yarn run desktop:build:prod   # compile necessary files
 $ yarn run web:build:prod
 
 # To build and run the web app using docker:
-$ docker build . -t foxbox
-$ docker run -p 8080:8080 foxbox
+$ docker build . -t lichtblick
+$ docker run -p 8080:8080 lichtblick
 
 # It is possible to clean up build files using the following command:
 $ yarn run clean
@@ -91,12 +91,12 @@ $ yarn run clean
 
 ## :pencil: License (Open Source)
 
-Foxbox follows an open core licensing model. Most functionality is available in this repository, and can be reproduced or modified per the terms of the [Mozilla Public License v2.0](/LICENSE).
+Lichtblick follows an open core licensing model. Most functionality is available in this repository, and can be reproduced or modified per the terms of the [Mozilla Public License v2.0](/LICENSE).
 
 ## :handshake: Contributing
 
-Contributions are welcome! Foxbox is primarily built in TypeScript and ReactJS. All potential contributors must agree to the Contributor License Agreement outlined in [CONTRIBUTING.md](CONTRIBUTING.md).
+Contributions are welcome! Lichtblick is primarily built in TypeScript and ReactJS. All potential contributors must agree to the Contributor License Agreement outlined in [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## :star: Credits
 
-Foxbox originally began as a fork of [FoxGlove Studio](https://github.com/foxglove/studio), an open source project developed by [Foxglove](https://app.foxglove.dev/).
+Lichtblick originally began as a fork of [FoxGlove Studio](https://github.com/foxglove/studio), an open source project developed by [Foxglove](https://app.foxglove.dev/).

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 <h1 align="center">Lichtblick</h1>
 
 <div align="center">
-  <a href="https://github.com/bmw-software-engineering/lichtblick/stargazers"><img src="https://img.shields.io/github/stars/bmw-software-engineerlichtblickxbox" alt="Stars Badge"/></a>
-  <a href="https://github.com/bmw-software-engineering/lichtblick/network/members"><img src="https://img.shields.io/github/forks/bmw-software-engineerlichtblickxbox" alt="Forks Badge"/></a>
-  <a href="https://github.com/bmw-software-engineering/lichtblick/pulls"><img src="https://img.shields.io/github/issues-pr/bmw-software-engineerlichtblickxbox" alt="Pull Requests Badge"/></a>
-  <a href="https://github.com/bmw-software-engineering/lichtblick/issues"><img src="https://img.shields.io/github/issues/bmw-software-engineerlichtblickxbox" alt="Issues Badge"/></a>
-  <a href="https://github.com/bmw-software-engineering/lichtblick/issues"><img src="https://img.shields.io/github/issues/bmw-software-engineerlichtblickxbox" alt="Version"/></a>
-  <a href="https://github.com/bmw-software-engineering/lichtblick/graphs/contributors"><img alt="GitHub contributors" src="https://img.shields.io/github/contributors/bmw-software-engineerlichtblickxbox?color=2b9348"></a>
-  <a href="https://github.com/bmw-software-engineering/lichtblick/blob/master/LICENSE"><img src="https://img.shields.io/github/license/bmw-software-engineerlichtblickxbox?color=2b9348" alt="License Badge"/></a>
+  <a href="https://github.com/bmw-software-engineering/lichtblick/stargazers"><img src="https://img.shields.io/github/stars/bmw-software-engineering/lichtblick" alt="Stars Badge"/></a>
+  <a href="https://github.com/bmw-software-engineering/lichtblick/network/members"><img src="https://img.shields.io/github/forks/bmw-software-engineering/lichtblick" alt="Forks Badge"/></a>
+  <a href="https://github.com/bmw-software-engineering/lichtblick/pulls"><img src="https://img.shields.io/github/issues-pr/bmw-software-engineering/lichtblick" alt="Pull Requests Badge"/></a>
+  <a href="https://github.com/bmw-software-engineering/lichtblick/issues"><img src="https://img.shields.io/github/issues/bmw-software-engineering/lichtblick" alt="Issues Badge"/></a>
+  <a href="https://github.com/bmw-software-engineering/lichtblick/issues"><img src="https://img.shields.io/github/issues/bmw-software-engineering/lichtblick" alt="Version"/></a>
+  <a href="https://github.com/bmw-software-engineering/lichtblick/graphs/contributors"><img alt="GitHub contributors" src="https://img.shields.io/github/contributors/bmw-software-engineering/lichtblick?color=2b9348"></a>
+  <a href="https://github.com/bmw-software-engineering/lichtblick/blob/master/LICENSE"><img src="https://img.shields.io/github/license/bmw-software-engineering/lichtblick?color=2b9348" alt="License Badge"/></a>
 
   <br />
 <p  align="center">

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -1,4 +1,4 @@
-# Foxbox Benchmarking
+# Lichtblick Benchmarking
 
 Benchmarks are specific combinations of layout and synthetic data playback. When a benchmark is opened, playback automatically starts and summary results are printed to the developer console.
 

--- a/benchmark/webpack.config.ts
+++ b/benchmark/webpack.config.ts
@@ -92,7 +92,7 @@ const mainConfig = (env: unknown, argv: WebpackArgv): Configuration => {
   <html>
     <head>
       <meta charset="utf-8">
-      <title>Foxbox Benchmark</title>
+      <title>Lichtblick Benchmark</title>
     </head>
     <script>
       global = globalThis;

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "name": "Lichtblick",
     "email": "lichtblick@bmwgroup.com"
   },
-  "homepage": "https://foxglove.dev/",
+  "homepage": "https://github.com/bmw-software-engineering",
   "engines": {
     "node": ">=16"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "foxbox",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "license": "MPL-2.0",
   "private": true,
   "productName": "Lichtblick",

--- a/package.json
+++ b/package.json
@@ -3,9 +3,9 @@
   "version": "1.2.0",
   "license": "MPL-2.0",
   "private": true,
-  "productName": "Foxbox",
-  "description": "Core components of Foxbox",
-  "productDescription": "Foxbox",
+  "productName": "Lichtblick",
+  "description": "Core components of Lichtblick",
+  "productDescription": "Lichtblick",
   "packageManager": "yarn@3.6.3",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,19 +1,19 @@
 {
-  "name": "foxbox",
+  "name": "lichtblick",
   "version": "1.2.1",
   "license": "MPL-2.0",
   "private": true,
   "productName": "Lichtblick",
   "description": "Core components of Lichtblick",
-  "productDescription": "Lichtblick",
+  "productDescription": "Lichtblick Suite",
   "packageManager": "yarn@3.6.3",
   "repository": {
     "type": "git",
     "url": "https://github.com/bmw-software-engineering/lichtblick.git"
   },
   "author": {
-    "name": "Foxglove Technologies",
-    "email": "support@foxglove.dev"
+    "name": "Lichtblick",
+    "email": "lichtblick@bmwgroup.com"
   },
   "homepage": "https://foxglove.dev/",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "packageManager": "yarn@3.6.3",
   "repository": {
     "type": "git",
-    "url": "https://github.com/foxglove/studio.git"
+    "url": "https://github.com/bmw-software-engineering/lichtblick.git"
   },
   "author": {
     "name": "Foxglove Technologies",

--- a/packages/comlink-transfer-handlers/package.json
+++ b/packages/comlink-transfer-handlers/package.json
@@ -7,8 +7,8 @@
     "url": "https://github.com/bmw-software-engineering/lichtblick.git"
   },
   "author": {
-    "name": "Foxglove Technologies",
-    "email": "support@foxglove.dev"
+    "name": "Lichtblick",
+    "email": "lichtblick@bmwgroup.com"
   },
   "homepage": "https://foxglove.dev/",
   "main": "./src/index.ts",

--- a/packages/comlink-transfer-handlers/package.json
+++ b/packages/comlink-transfer-handlers/package.json
@@ -10,7 +10,7 @@
     "name": "Lichtblick",
     "email": "lichtblick@bmwgroup.com"
   },
-  "homepage": "https://foxglove.dev/",
+  "homepage": "https://github.com/bmw-software-engineering",
   "main": "./src/index.ts",
   "files": [
     "dist",

--- a/packages/comlink-transfer-handlers/package.json
+++ b/packages/comlink-transfer-handlers/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "repository": {
     "type": "git",
-    "url": "https://github.com/foxglove/studio.git"
+    "url": "https://github.com/bmw-software-engineering/lichtblick.git"
   },
   "author": {
     "name": "Foxglove Technologies",

--- a/packages/den/package.json
+++ b/packages/den/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "repository": {
     "type": "git",
-    "url": "https://github.com/foxglove/studio.git"
+    "url": "https://github.com/bmw-software-engineering/lichtblick.git"
   },
   "author": {
     "name": "Foxglove Technologies",

--- a/packages/den/package.json
+++ b/packages/den/package.json
@@ -8,8 +8,8 @@
     "url": "https://github.com/bmw-software-engineering/lichtblick.git"
   },
   "author": {
-    "name": "Foxglove Technologies",
-    "email": "support@foxglove.dev"
+    "name": "Lichtblick",
+    "email": "lichtblick@bmwgroup.com"
   },
   "homepage": "https://foxglove.dev/",
   "dependencies": {

--- a/packages/den/package.json
+++ b/packages/den/package.json
@@ -11,7 +11,7 @@
     "name": "Lichtblick",
     "email": "lichtblick@bmwgroup.com"
   },
-  "homepage": "https://foxglove.dev/",
+  "homepage": "https://github.com/bmw-software-engineering",
   "dependencies": {
     "async-mutex": "0.4.0",
     "comlink": "github:foxglove/comlink#9181fa505671b35b1e66e0a8361a6fc1bdd03307",

--- a/packages/eslint-plugin-studio/package.json
+++ b/packages/eslint-plugin-studio/package.json
@@ -7,8 +7,8 @@
     "url": "https://github.com/bmw-software-engineering/lichtblick.git"
   },
   "author": {
-    "name": "Foxglove Technologies",
-    "email": "support@foxglove.dev"
+    "name": "Lichtblick",
+    "email": "lichtblick@bmwgroup.com"
   },
   "homepage": "https://foxglove.dev/",
   "main": "./index.js",

--- a/packages/eslint-plugin-studio/package.json
+++ b/packages/eslint-plugin-studio/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "repository": {
     "type": "git",
-    "url": "https://github.com/foxglove/studio.git"
+    "url": "https://github.com/bmw-software-engineering/lichtblick.git"
   },
   "author": {
     "name": "Foxglove Technologies",

--- a/packages/eslint-plugin-studio/package.json
+++ b/packages/eslint-plugin-studio/package.json
@@ -10,7 +10,7 @@
     "name": "Lichtblick",
     "email": "lichtblick@bmwgroup.com"
   },
-  "homepage": "https://foxglove.dev/",
+  "homepage": "https://github.com/bmw-software-engineering",
   "main": "./index.js",
   "files": [
     "src"

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -7,8 +7,8 @@
     "url": "https://github.com/bmw-software-engineering/lichtblick.git"
   },
   "author": {
-    "name": "Foxglove Technologies",
-    "email": "support@foxglove.dev"
+    "name": "Lichtblick",
+    "email": "lichtblick@bmwgroup.com"
   },
   "homepage": "https://foxglove.dev/",
   "main": "./src/index.ts",

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -10,7 +10,7 @@
     "name": "Lichtblick",
     "email": "lichtblick@bmwgroup.com"
   },
-  "homepage": "https://foxglove.dev/",
+  "homepage": "https://github.com/bmw-software-engineering",
   "main": "./src/index.ts",
   "files": [
     "dist",

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "repository": {
     "type": "git",
-    "url": "https://github.com/foxglove/studio.git"
+    "url": "https://github.com/bmw-software-engineering/lichtblick.git"
   },
   "author": {
     "name": "Foxglove Technologies",

--- a/packages/log/package.json
+++ b/packages/log/package.json
@@ -7,8 +7,8 @@
     "url": "https://github.com/bmw-software-engineering/lichtblick.git"
   },
   "author": {
-    "name": "Foxglove Technologies",
-    "email": "support@foxglove.dev"
+    "name": "Lichtblick",
+    "email": "lichtblick@bmwgroup.com"
   },
   "homepage": "https://foxglove.dev/",
   "main": "./src/index.ts",

--- a/packages/log/package.json
+++ b/packages/log/package.json
@@ -10,7 +10,7 @@
     "name": "Lichtblick",
     "email": "lichtblick@bmwgroup.com"
   },
-  "homepage": "https://foxglove.dev/",
+  "homepage": "https://github.com/bmw-software-engineering",
   "main": "./src/index.ts",
   "files": [
     "dist",

--- a/packages/log/package.json
+++ b/packages/log/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "repository": {
     "type": "git",
-    "url": "https://github.com/foxglove/studio.git"
+    "url": "https://github.com/bmw-software-engineering/lichtblick.git"
   },
   "author": {
     "name": "Foxglove Technologies",

--- a/packages/mcap-support/package.json
+++ b/packages/mcap-support/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "repository": {
     "type": "git",
-    "url": "https://github.com/foxglove/studio.git"
+    "url": "https://github.com/bmw-software-engineering/lichtblick.git"
   },
   "author": {
     "name": "Foxglove Technologies",

--- a/packages/mcap-support/package.json
+++ b/packages/mcap-support/package.json
@@ -8,8 +8,8 @@
     "url": "https://github.com/bmw-software-engineering/lichtblick.git"
   },
   "author": {
-    "name": "Foxglove Technologies",
-    "email": "support@foxglove.dev"
+    "name": "Lichtblick",
+    "email": "lichtblick@bmwgroup.com"
   },
   "homepage": "https://foxglove.dev/",
   "main": "./src/index.ts",

--- a/packages/mcap-support/package.json
+++ b/packages/mcap-support/package.json
@@ -11,7 +11,7 @@
     "name": "Lichtblick",
     "email": "lichtblick@bmwgroup.com"
   },
-  "homepage": "https://foxglove.dev/",
+  "homepage": "https://github.com/bmw-software-engineering",
   "main": "./src/index.ts",
   "files": [
     "dist",

--- a/packages/message-path/package.json
+++ b/packages/message-path/package.json
@@ -7,8 +7,8 @@
     "url": "https://github.com/bmw-software-engineering/lichtblick.git"
   },
   "author": {
-    "name": "Foxglove Technologies",
-    "email": "support@foxglove.dev"
+    "name": "Lichtblick",
+    "email": "lichtblick@bmwgroup.com"
   },
   "homepage": "https://foxglove.dev/",
   "main": "./src/index.ts",

--- a/packages/message-path/package.json
+++ b/packages/message-path/package.json
@@ -10,7 +10,7 @@
     "name": "Lichtblick",
     "email": "lichtblick@bmwgroup.com"
   },
-  "homepage": "https://foxglove.dev/",
+  "homepage": "https://github.com/bmw-software-engineering",
   "main": "./src/index.ts",
   "files": [
     "dist",

--- a/packages/message-path/package.json
+++ b/packages/message-path/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "repository": {
     "type": "git",
-    "url": "https://github.com/foxglove/studio.git"
+    "url": "https://github.com/bmw-software-engineering/lichtblick.git"
   },
   "author": {
     "name": "Foxglove Technologies",

--- a/packages/studio-base/README.md
+++ b/packages/studio-base/README.md
@@ -1,10 +1,10 @@
 # @foxglove/studio-base &nbsp; [![npm version](https://img.shields.io/npm/v/@foxglove/studio-base.svg?style=flat)](https://www.npmjs.com/package/@foxglove/studio-base)
 
-This package contains core components used in [Foxbox](https://github.com/foxglove/studio).
+This package contains core components used in [Lichtblick](https://github.com/foxglove/studio).
 
 ## Quick start
 
-When contributing to the [Foxbox](https://github.com/foxglove/studio) codebase, you can import from `@foxglove/studio-base` at its top-level or from lower in its directory:
+When contributing to the [Lichtblick](https://github.com/foxglove/studio) codebase, you can import from `@foxglove/studio-base` at its top-level or from lower in its directory:
 
 ```
 import { ExtensionInfo, ExtensionLoaderContext, ExtensionLoader } from "@foxglove/studio-base";

--- a/packages/studio-base/package.json
+++ b/packages/studio-base/package.json
@@ -2,8 +2,8 @@
   "name": "@foxglove/studio-base",
   "description": "Core components of Foxglove Studio",
   "private": true,
-  "productName": "Foxglove",
-  "productDescription": "Foxglove Studio",
+  "productName": "Lichtblick",
+  "productDescription": "Lichtblick",
   "license": "MPL-2.0",
   "repository": {
     "type": "git",

--- a/packages/studio-base/package.json
+++ b/packages/studio-base/package.json
@@ -3,15 +3,15 @@
   "description": "Core components of Foxglove Studio",
   "private": true,
   "productName": "Lichtblick",
-  "productDescription": "Lichtblick",
+  "productDescription": "Lichtblick Suite",
   "license": "MPL-2.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/foxglove/studio/tree/main/packages/studio-base"
   },
   "author": {
-    "name": "Foxglove Technologies",
-    "email": "support@foxglove.dev"
+    "name": "Lichtblick",
+    "email": "lichtblick@bmwgroup.com"
   },
   "homepage": "https://foxglove.dev/",
   "main": "src/index",

--- a/packages/studio-base/package.json
+++ b/packages/studio-base/package.json
@@ -13,7 +13,7 @@
     "name": "Lichtblick",
     "email": "lichtblick@bmwgroup.com"
   },
-  "homepage": "https://foxglove.dev/",
+  "homepage": "https://github.com/bmw-software-engineering",
   "main": "src/index",
   "devDependencies": {
     "@emotion/cache": "11.13.0",

--- a/packages/studio-base/src/PanelAPI/README.md
+++ b/packages/studio-base/src/PanelAPI/README.md
@@ -1,6 +1,6 @@
 # PanelAPI
 
-The `PanelAPI` namespace contains React [Hooks](https://reactjs.org/docs/hooks-intro.html) and components which allow panel authors to access Foxbox data and metadata inside their panels. Using these APIs across all panels helps ensure that data appears consistent among panels, and makes it easier for panels to support advanced features (such as multiple simultaneous data sources).
+The `PanelAPI` namespace contains React [Hooks](https://reactjs.org/docs/hooks-intro.html) and components which allow panel authors to access Lichtblick data and metadata inside their panels. Using these APIs across all panels helps ensure that data appears consistent among panels, and makes it easier for panels to support advanced features (such as multiple simultaneous data sources).
 
 To use PanelAPI, it's recommended that you import the whole namespace, so that all usage sites look consistent, like `PanelAPI.useSomething()`.
 
@@ -10,7 +10,7 @@ import * as PanelAPI from "@foxglove/studio-base/PanelAPI";
 
 ## [`PanelAPI.useDataSourceInfo()`](useDataSourceInfo.js)
 
-"Data source info" encapsulates **rarely-changing** metadata about the sources from which Foxbox is loading data. (A data source might be a local [bag file](http://wiki.ros.org/Bags/Format) dropped into the browser, or a bag stored on a remote server; see [players](../players) and [dataSources](../dataSources) for more details.)
+"Data source info" encapsulates **rarely-changing** metadata about the sources from which Lichtblick is loading data. (A data source might be a local [bag file](http://wiki.ros.org/Bags/Format) dropped into the browser, or a bag stored on a remote server; see [players](../players) and [dataSources](../dataSources) for more details.)
 
 Using this hook inside a panel will cause the panel to re-render automatically when the metadata changes, but this won't happen very often or during playback.
 
@@ -63,7 +63,7 @@ These reducers should be wrapped in [`useCallback()`](https://reactjs.org/docs/h
 
 - `restore: (?T) => T`:
 
-  - Called with `undefined` to initialize a new state when the panel first renders, and when the user seeks to a different playback time (at which point Foxbox automatically clears out state across all panels).
+  - Called with `undefined` to initialize a new state when the panel first renders, and when the user seeks to a different playback time (at which point Lichtblick automatically clears out state across all panels).
   - Called with the previous state when the `restore` or `addMessage`/`addMessages` reducer functions change. This allows the panel an opportunity to reuse its previous state when a parameter changes, without totally discarding it (as in the case of a seek) and waiting for new messages to come in from the data source.
 
     For example, a panel that filters some incoming messages can use `restore` to create a filtered value immediately when the filter changes. To implement this, the caller might switch from unfiltered reducers:

--- a/packages/studio-base/src/PanelAPI/index.ts
+++ b/packages/studio-base/src/PanelAPI/index.ts
@@ -12,14 +12,14 @@
 //   You may not use this file except in compliance with the License.
 
 // This file contains hooks and components comprising the public API for
-// Foxglove Studio panel development.
+// Lichtblick panel development.
 // Recommended use: import * as PanelAPI from "@foxglove/studio-base/PanelAPI";
 
 export { useDataSourceInfo } from "./useDataSourceInfo";
 
 export { useMessageReducer } from "./useMessageReducer";
 
-export { useMessagesByTopic } from "./useMessagesByTopic";
 export { useBlocksSubscriptions } from "./useBlocksSubscriptions";
+export { useMessagesByTopic } from "./useMessagesByTopic";
 
 export { default as useConfigById } from "./useConfigById";

--- a/packages/studio-base/src/components/AppBar/AppMenu.tsx
+++ b/packages/studio-base/src/components/AppBar/AppMenu.tsx
@@ -187,11 +187,6 @@ export function AppMenu(props: AppMenuProps): JSX.Element {
     handleNestedMenuClose();
   }, [dialogActions.preferences, handleNestedMenuClose]);
 
-  const onDocsClick = useCallback(() => {
-    window.open("https://docs.foxglove.dev/docs", "_blank");
-    handleNestedMenuClose();
-  }, [handleNestedMenuClose]);
-
   const onDemoClick = useCallback(() => {
     dialogActions.dataSource.open("demo");
     handleNestedMenuClose();
@@ -201,11 +196,9 @@ export function AppMenu(props: AppMenuProps): JSX.Element {
     () => [
       { type: "item", key: "about", label: t("about"), onClick: onAboutClick },
       { type: "divider" },
-      { type: "item", key: "docs", label: t("viewOurDocs"), onClick: onDocsClick, external: true },
-      { type: "divider" },
       { type: "item", key: "demo", label: t("exploreSampleData"), onClick: onDemoClick },
     ],
-    [onAboutClick, onDemoClick, onDocsClick, t],
+    [onAboutClick, onDemoClick, t],
   );
 
   return (

--- a/packages/studio-base/src/components/AppBar/HelpMenu.tsx
+++ b/packages/studio-base/src/components/AppBar/HelpMenu.tsx
@@ -9,7 +9,7 @@ import {
   MenuItem,
   PopoverOrigin,
   PopoverPosition,
-  PopoverReference
+  PopoverReference,
 } from "@mui/material";
 import { makeStyles } from "tss-react/mui";
 

--- a/packages/studio-base/src/components/AppBar/HelpMenu.tsx
+++ b/packages/studio-base/src/components/AppBar/HelpMenu.tsx
@@ -2,15 +2,14 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { Cloud24Regular, SlideLayout24Regular } from "@fluentui/react-icons";
+import { Cloud24Regular } from "@fluentui/react-icons";
 import {
   ListItemText,
-  ListSubheader,
   Menu,
   MenuItem,
   PopoverOrigin,
   PopoverPosition,
-  PopoverReference,
+  PopoverReference
 } from "@mui/material";
 import { makeStyles } from "tss-react/mui";
 
@@ -19,10 +18,6 @@ import { useCurrentUserType } from "@foxglove/studio-base/context/CurrentUserCon
 import { AppEvent } from "@foxglove/studio-base/services/IAnalytics";
 
 const useStyles = makeStyles()((theme) => ({
-  subheader: {
-    bgcolor: "transparent",
-    border: "none",
-  },
   paper: {
     width: 280,
   },
@@ -81,27 +76,6 @@ export function HelpMenu(props: HelpMenuProps): JSX.Element {
         "aria-labelledby": "help-button",
       }}
     >
-      <ListSubheader className={classes.subheader}>Documentation</ListSubheader>
-      <MenuItem
-        href="https://foxglove.dev/docs/studio"
-        className={classes.menuItem}
-        component="a"
-        target="_blank"
-        onClick={() => {
-          void analytics.logEvent(AppEvent.HELP_MENU_CLICK_CTA, {
-            user: currentUserType,
-            cta: "docs-studio",
-          });
-          handleClose();
-        }}
-      >
-        <SlideLayout24Regular className={classes.icon} />
-        <ListItemText
-          primary="Studio"
-          secondary="Open source robotics visualization and debugging"
-          secondaryTypographyProps={{ className: classes.menuText }}
-        />
-      </MenuItem>
       <MenuItem
         href="https://foxglove.dev/docs/data-platform"
         className={classes.menuItem}

--- a/packages/studio-base/src/components/AppBar/SettingsMenu.tsx
+++ b/packages/studio-base/src/components/AppBar/SettingsMenu.tsx
@@ -3,12 +3,11 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import {
-  Divider,
   Menu,
   MenuItem,
   PaperProps,
   PopoverPosition,
-  PopoverReference,
+  PopoverReference
 } from "@mui/material";
 import { useCallback } from "react";
 import { useTranslation } from "react-i18next";
@@ -51,11 +50,6 @@ export function SettingsMenu({
     },
     [dialogActions.preferences],
   );
-
-  const onDocsClick = useCallback(() => {
-    window.open("https://docs.foxglove.dev/docs", "_blank");
-  }, []);
-
   return (
     <>
       <Menu
@@ -88,8 +82,6 @@ export function SettingsMenu({
         >
           {t("extensions")}
         </MenuItem>
-        <Divider variant="middle" />
-        <MenuItem onClick={onDocsClick}>{t("documentation")}</MenuItem>
       </Menu>
     </>
   );

--- a/packages/studio-base/src/components/AppBar/SettingsMenu.tsx
+++ b/packages/studio-base/src/components/AppBar/SettingsMenu.tsx
@@ -2,13 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import {
-  Menu,
-  MenuItem,
-  PaperProps,
-  PopoverPosition,
-  PopoverReference
-} from "@mui/material";
+import { Menu, MenuItem, PaperProps, PopoverPosition, PopoverReference } from "@mui/material";
 import { useCallback } from "react";
 import { useTranslation } from "react-i18next";
 import { makeStyles } from "tss-react/mui";

--- a/packages/studio-base/src/components/AppBar/index.tsx
+++ b/packages/studio-base/src/components/AppBar/index.tsx
@@ -16,7 +16,7 @@ import { useTranslation } from "react-i18next";
 import tc from "tinycolor2";
 import { makeStyles } from "tss-react/mui";
 
-import { FoxboxLogo } from "@foxglove/studio-base/components/FoxboxLogo";
+import { LichtblickLogo } from "@foxglove/studio-base/components/LichtblickLogo";
 import Stack from "@foxglove/studio-base/components/Stack";
 import { useAppContext } from "@foxglove/studio-base/context/AppContext";
 import {
@@ -208,7 +208,7 @@ export function AppBar(props: AppBarProps): JSX.Element {
                   setAppMenuEl(event.currentTarget);
                 }}
               >
-                <FoxboxLogo fontSize="inherit" color="inherit" />
+                <LichtblickLogo fontSize="inherit" color="inherit" />
                 <ChevronDown12Regular
                   className={classes.dropDownIcon}
                   primaryFill={theme.palette.common.white}

--- a/packages/studio-base/src/components/AppSettingsDialog/AppSettingsDialog.tsx
+++ b/packages/studio-base/src/components/AppSettingsDialog/AppSettingsDialog.tsx
@@ -140,37 +140,6 @@ const aboutItems = new Map<
   }
 >([
   [
-    "resources",
-    {
-      subheader: "External resources",
-      links: [
-        ...(isDesktopApp() ? [] : [{ title: "Desktop app", url: "https://foxglove.dev/download" }]),
-        { title: "Browse docs", url: "https://docs.foxglove.dev/docs" },
-        { title: "Join our community", url: "https://foxglove.dev/community" },
-      ],
-    },
-  ],
-  [
-    "products",
-    {
-      subheader: "Products",
-      links: [
-        { title: "Foxglove Studio", url: "https://foxglove.dev/studio" },
-        { title: "Foxglove Data Platform", url: "https://foxglove.dev/data-platform" },
-      ],
-    },
-  ],
-  [
-    "contact",
-    {
-      subheader: "Contact",
-      links: [
-        { title: "Give feedback", url: "https://foxglove.dev/contact" },
-        { title: "Schedule a demo", url: "https://foxglove.dev/demo" },
-      ],
-    },
-  ],
-  [
     "legal",
     {
       subheader: "Legal",

--- a/packages/studio-base/src/components/AppSettingsDialog/AppSettingsDialog.tsx
+++ b/packages/studio-base/src/components/AppSettingsDialog/AppSettingsDialog.tsx
@@ -213,7 +213,6 @@ export function AppSettingsDialog(
           onChange={handleTabChange}
         >
           <Tab className={classes.tab} label={t("general")} value="general" />
-          <Tab className={classes.tab} label={t("privacy")} value="privacy" />
           <Tab className={classes.tab} label={t("extensions")} value="extensions" />
           <Tab
             className={classes.tab}

--- a/packages/studio-base/src/components/AppSettingsDialog/AppSettingsDialog.tsx
+++ b/packages/studio-base/src/components/AppSettingsDialog/AppSettingsDialog.tsx
@@ -30,7 +30,7 @@ import OsContextSingleton from "@foxglove/studio-base/OsContextSingleton";
 import CopyButton from "@foxglove/studio-base/components/CopyButton";
 import { ExperimentalFeatureSettings } from "@foxglove/studio-base/components/ExperimentalFeatureSettings";
 import ExtensionsSettings from "@foxglove/studio-base/components/ExtensionsSettings";
-import FoxboxLogoText from "@foxglove/studio-base/components/FoxboxLogoText";
+import LichtblickLogoText from "@foxglove/studio-base/components/LichtblickLogoText";
 import Stack from "@foxglove/studio-base/components/Stack";
 import { useAppContext } from "@foxglove/studio-base/context/AppContext";
 import {
@@ -315,10 +315,12 @@ export function AppSettingsDialog(
           >
             <Stack gap={2} alignItems="flex-start">
               <header>
-                <FoxboxLogoText color="primary" className={classes.logo} />
+                <LichtblickLogoText color="primary" className={classes.logo} />
               </header>
               <Stack direction="row" alignItems="center" gap={1}>
-                <Typography variant="body2">Foxbox version {FOXGLOVE_STUDIO_VERSION}</Typography>
+                <Typography variant="body2">
+                  Lichtblick version {FOXGLOVE_STUDIO_VERSION}
+                </Typography>
                 <CopyButton
                   size="small"
                   getText={() => FOXGLOVE_STUDIO_VERSION?.toString() ?? ""}

--- a/packages/studio-base/src/components/DataSourceDialog/Start.tsx
+++ b/packages/studio-base/src/components/DataSourceDialog/Start.tsx
@@ -186,20 +186,6 @@ function SidebarItems(props: {
           >
             {t("exploreSampleData")}
           </Button>
-          <Button
-            href="https://docs.foxglove.dev/docs/connecting-to-data/introduction"
-            target="_blank"
-            className={classes.button}
-            disabled
-            onClick={() => {
-              void analytics.logEvent(AppEvent.DIALOG_CLICK_CTA, {
-                user: currentUserType,
-                cta: "docs",
-              });
-            }}
-          >
-            {t("viewOurDocs")}
-          </Button>
         </>
       ),
     };
@@ -213,20 +199,6 @@ function SidebarItems(props: {
           text: t("needHelpDescription"),
           actions: (
             <>
-              <Button
-                href="https://docs.foxglove.dev/docs"
-                target="_blank"
-                className={classes.button}
-                variant="outlined"
-                onClick={() => {
-                  void analytics.logEvent(AppEvent.DIALOG_CLICK_CTA, {
-                    user: currentUserType,
-                    cta: "docs",
-                  });
-                }}
-              >
-                {t("viewOurDocs")}
-              </Button>
               <Button
                 href="https://foxglove.dev/tutorials"
                 target="_blank"

--- a/packages/studio-base/src/components/DataSourceDialog/Start.tsx
+++ b/packages/studio-base/src/components/DataSourceDialog/Start.tsx
@@ -9,7 +9,7 @@ import tinycolor from "tinycolor2";
 import { makeStyles } from "tss-react/mui";
 
 import { DataSourceDialogItem } from "@foxglove/studio-base/components/DataSourceDialog/DataSourceDialog";
-import FoxboxLogoText from "@foxglove/studio-base/components/FoxboxLogoText";
+import LichtblickLogoText from "@foxglove/studio-base/components/LichtblickLogoText";
 import Stack from "@foxglove/studio-base/components/Stack";
 import TextMiddleTruncate from "@foxglove/studio-base/components/TextMiddleTruncate";
 import { useAnalytics } from "@foxglove/studio-base/context/AnalyticsContext";
@@ -356,7 +356,7 @@ export default function Start(): JSX.Element {
   return (
     <Stack className={classes.grid}>
       <header className={classes.header}>
-        <FoxboxLogoText color="primary" className={classes.logo} />
+        <LichtblickLogoText color="primary" className={classes.logo} />
       </header>
       <Stack className={classes.content}>
         <Stack gap={4}>

--- a/packages/studio-base/src/components/DocumentTitleAdapter.tsx
+++ b/packages/studio-base/src/components/DocumentTitleAdapter.tsx
@@ -19,12 +19,12 @@ export default function DocumentTitleAdapter(): JSX.Element {
 
   useEffect(() => {
     if (!playerName) {
-      window.document.title = "Foxbox";
+      window.document.title = "Lichtblick";
       return;
     }
     window.document.title = navigator.userAgent.includes("Mac")
       ? playerName
-      : `${playerName} – Foxbox`;
+      : `${playerName} – Lichtblick`;
   }, [playerName]);
 
   return <></>;

--- a/packages/studio-base/src/components/LayoutBrowser/index.tsx
+++ b/packages/studio-base/src/components/LayoutBrowser/index.tsx
@@ -604,7 +604,7 @@ export default function LayoutBrowser({
         <LayoutSection
           disablePadding={enableNewTopNav}
           title={layoutManager.supportsSharing ? "Personal" : undefined}
-          emptyText="Add a new layout to get started with Foxglove Studio!"
+          emptyText="Add a new layout to get started with Lichtblick!"
           items={layouts.value?.personal}
           anySelectedModifiedLayouts={anySelectedModifiedLayouts}
           multiSelectedIds={state.selectedIds}

--- a/packages/studio-base/src/components/LichtblickLogo.tsx
+++ b/packages/studio-base/src/components/LichtblickLogo.tsx
@@ -4,10 +4,10 @@
 
 import { SvgIcon, SvgIconProps } from "@mui/material";
 
-export function FoxboxLogo(props: SvgIconProps): JSX.Element {
+export function LichtblickLogo(props: SvgIconProps): JSX.Element {
   return (
     <SvgIcon viewBox="0 0 512 512" {...props}>
-      <title>Foxbox</title>
+      <title>Lichtblick</title>
       <svg
         xmlns="http://www.w3.org/2000/svg"
         fill="currentColor"

--- a/packages/studio-base/src/components/LichtblickLogoText.tsx
+++ b/packages/studio-base/src/components/LichtblickLogoText.tsx
@@ -4,10 +4,10 @@
 
 import { SvgIcon, SvgIconProps } from "@mui/material";
 
-export default function FoxboxLogoText(props: SvgIconProps): JSX.Element {
+export default function LichtblickLogoText(props: SvgIconProps): JSX.Element {
   return (
     <SvgIcon viewBox="0 0 909 204" {...props}>
-      <title>Foxbox</title>
+      <title>Lichtblick</title>
       <g>
         <svg
           width="909"

--- a/packages/studio-base/src/i18n/README.md
+++ b/packages/studio-base/src/i18n/README.md
@@ -1,3 +1,3 @@
-This directory contains localized strings for languages supported by Foxbox.
+This directory contains localized strings for languages supported by Lichtblick.
 
 To learn more about localization, see [CONTRIBUTING.md](../../../../CONTRIBUTING.md#localization).

--- a/packages/studio-base/src/i18n/en/appBar.ts
+++ b/packages/studio-base/src/i18n/en/appBar.ts
@@ -5,7 +5,6 @@
 export const appBar = {
   about: "About",
   addPanel: "Add panel",
-  documentation: "Documentation",
   exploreSampleData: "Explore sample data",
   exportLayoutToFile: "Export layout to file…",
   extensions: "Extensions",
@@ -30,5 +29,4 @@ export const appBar = {
   userProfile: "User profile",
   view: "View",
   viewData: "View data",
-  viewOurDocs: "View our docs",
 };

--- a/packages/studio-base/src/i18n/en/appSettings.ts
+++ b/packages/studio-base/src/i18n/en/appSettings.ts
@@ -25,7 +25,6 @@ export const appSettings = {
   newAppMenuDescription: "Show the new menu and navigation.",
   noExperimentalFeatures: "Currently there are no experimental features.",
   openLinksIn: "Open links in",
-  privacy: "Privacy",
   ros: "ROS",
   settings: "Settings",
   timestampFormat: "Timestamp format",

--- a/packages/studio-base/src/i18n/en/appSettings.ts
+++ b/packages/studio-base/src/i18n/en/appSettings.ts
@@ -8,7 +8,7 @@ export const appSettings = {
   askEachTime: "Ask each time",
   colorScheme: "Color scheme",
   dark: "Dark",
-  debugModeDescription: "Enable panels and features for debugging Foxbox",
+  debugModeDescription: "Enable panels and features for debugging Lichtblick",
   desktopApp: "Desktop app",
   displayTimestampsIn: "Display timestamps in",
   experimentalFeatures: "Experimental features",

--- a/packages/studio-base/src/i18n/en/incompatibleLayoutVersion.ts
+++ b/packages/studio-base/src/i18n/en/incompatibleLayoutVersion.ts
@@ -4,7 +4,8 @@
 
 export const incompatibleLayoutVersion = {
   desktopText:
-    "This layout was created with a newer version of Foxbox. Please update to the latest version at ",
+    "This layout was created with a newer version of Lichtblick. Please update to the latest version at ",
   title: "Incompatible layout version",
-  webText: "This layout was created with a newer version of Foxbox. Please refresh your browser.",
+  webText:
+    "This layout was created with a newer version of Lichtblick. Please refresh your browser.",
 };

--- a/packages/studio-base/src/i18n/en/openDialog.ts
+++ b/packages/studio-base/src/i18n/en/openDialog.ts
@@ -32,5 +32,4 @@ export const openDialog = {
   startCollaboratingDescription:
     "Make the most of your Foxglove account – whether you want to dive deep on your data or share tools with your teammates.",
   uploadToDataPlatform: "Upload to Data Platform",
-  viewOurDocs: "View our docs",
 };

--- a/packages/studio-base/src/i18n/en/openDialog.ts
+++ b/packages/studio-base/src/i18n/en/openDialog.ts
@@ -4,7 +4,7 @@
 
 export const openDialog = {
   canBeShared: "Share data files, visualization layouts, and custom extensions with teammates",
-  collaborateTitle: "Accelerate development with Foxbox Data Platform",
+  collaborateTitle: "Accelerate development with Lichtblick Data Platform",
   convenientWebInterface:
     "Use a convenient web interface to tag, search, and retrieve data at lightning speed",
   createAFreeAccount: "Create a free account",
@@ -12,7 +12,7 @@ export const openDialog = {
   learnMore: "Learn more",
   needHelp: "Need help?",
   needHelpDescription: "View our documentation, or check out the tutorials on the Foxglove blog.",
-  newToFoxgloveStudio: "New to Foxbox?",
+  newToFoxgloveStudio: "New to Lichtblick?",
   newToFoxgloveStudioDescription:
     "Start by exploring a sample dataset or checking out our documentation.",
   openAGitHubIssue: "Open a GitHub issue",

--- a/packages/studio-base/src/players/IterablePlayer/rosdb3/RosDb3IterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/rosdb3/RosDb3IterableSource.ts
@@ -84,7 +84,7 @@ export class RosDb3IterableSource implements IIterableSource {
         problems.push({
           severity: "warn",
           message: `Topic "${topicDef.name}" has unsupported datatype "${topicDef.type}"`,
-          tip: "ROS 2 .db3 files do not contain message definitions, so only well-known ROS types are supported in Foxbox. As a workaround, you can convert the db3 file to mcap using the mcap CLI. For more information, see: https://docs.foxglove.dev/docs/connecting-to-data/frameworks/ros2",
+          tip: "ROS 2 .db3 files do not contain message definitions, so only well-known ROS types are supported in Lichtblick. As a workaround, you can convert the db3 file to mcap using the mcap CLI. For more information, see: https://docs.foxglove.dev/docs/connecting-to-data/frameworks/ros2",
         });
         continue;
       }

--- a/packages/studio-base/src/players/UserScriptPlayer/transformerWorker/__snapshots__/generateRosLib.test.ts.snap
+++ b/packages/studio-base/src/players/UserScriptPlayer/transformerWorker/__snapshots__/generateRosLib.test.ts.snap
@@ -40,7 +40,7 @@ exports[`typegen generateRosLib basic snapshot 1`] = `
      * Input<"/your_input_topic_2">'.
      *
      * These types are dynamically generated from the bag(s) currently in your
-     * Foxglove Studio session, so if a datatype changes, your User Script
+     * Lichtblick session, so if a datatype changes, your User Script
      * may not compile on the newly formatted bag.
      */
     export declare interface Input<T extends keyof TopicsToMessageDefinition> {
@@ -292,7 +292,7 @@ exports[`typegen generateRosLib more complex snapshot 1`] = `
      * Input<"/your_input_topic_2">'.
      *
      * These types are dynamically generated from the bag(s) currently in your
-     * Foxglove Studio session, so if a datatype changes, your User Script
+     * Lichtblick session, so if a datatype changes, your User Script
      * may not compile on the newly formatted bag.
      */
     export declare interface Input<T extends keyof TopicsToMessageDefinition> {
@@ -332,7 +332,7 @@ exports[`typegen generateRosLib works with zero topics or datatypes 1`] = `
      * Input<"/your_input_topic_2">'.
      *
      * These types are dynamically generated from the bag(s) currently in your
-     * Foxglove Studio session, so if a datatype changes, your User Script
+     * Lichtblick session, so if a datatype changes, your User Script
      * may not compile on the newly formatted bag.
      */
     export declare interface Input<T extends keyof TopicsToMessageDefinition> {

--- a/packages/studio-base/src/players/UserScriptPlayer/transformerWorker/generateRosLib.ts
+++ b/packages/studio-base/src/players/UserScriptPlayer/transformerWorker/generateRosLib.ts
@@ -268,7 +268,7 @@ const generateRosLib = ({
      * Input<"/your_input_topic_2">'.
      *
      * These types are dynamically generated from the bag(s) currently in your
-     * Foxglove Studio session, so if a datatype changes, your User Script
+     * Lichtblick session, so if a datatype changes, your User Script
      * may not compile on the newly formatted bag.
      */
     ${printer.printNode(ts.EmitHint.Unspecified, typedMessage, sourceFile)}

--- a/packages/studio-base/src/players/UserScriptPlayer/transformerWorker/typescript/ros.ts
+++ b/packages/studio-base/src/players/UserScriptPlayer/transformerWorker/typescript/ros.ts
@@ -36,7 +36,7 @@ export const ros_lib_dts = `
    * Input<"/your_input_topic_2">'.
    *
    * These types are dynamically generated from the bag(s) currently in your
-   * Foxglove Studio session, so if a datatype changes, your User Script
+   * Lichtblick session, so if a datatype changes, your User Script
    * may not compile on the newly formatted bag.
    */
   export declare interface Input<T extends keyof TopicsToMessageDefinition> {

--- a/packages/studio-base/src/screens/LaunchPreferenceScreen.tsx
+++ b/packages/studio-base/src/screens/LaunchPreferenceScreen.tsx
@@ -79,7 +79,7 @@ export function LaunchPreferenceScreen(): ReactElement {
 
   return (
     <Dialog open classes={{ paper: classes.paper }}>
-      <DialogTitle className={classes.dialogTitle}>Launch Foxbox</DialogTitle>
+      <DialogTitle className={classes.dialogTitle}>Launch Lichtblick</DialogTitle>
       <DialogContent>
         <Grid container spacing={1}>
           {actions.map((action) => (

--- a/packages/studio-base/src/screens/LaunchingInDesktopScreen.tsx
+++ b/packages/studio-base/src/screens/LaunchingInDesktopScreen.tsx
@@ -68,7 +68,7 @@ export function LaunchingInDesktopScreen(): ReactElement {
         style={{ maxWidth: 480 }}
       >
         <Typography align="center" variant="h2" fontWeight={600}>
-          Launching Foxbox…
+          Launching Lichtblick…
         </Typography>
         <Typography align="center" fontWeight={600}>
           We’ve directed you to the desktop app.
@@ -86,10 +86,10 @@ export function LaunchingInDesktopScreen(): ReactElement {
             <Link
               color="primary"
               underline="hover"
-              href="https://foxglove.dev/download"
+              href="https://github.com/bmw-software-engineering/lichtblick/releases"
               target="_blank"
             >
-              Download Foxglove Studio
+              Download Lichtblick
             </Link>
           </Typography>
         </Stack>

--- a/packages/studio-base/src/util/enums.ts
+++ b/packages/studio-base/src/util/enums.ts
@@ -41,7 +41,7 @@ export const constantsByDatatype = (
 
 const extractTypeFromStudioEnumAnnotationRegex = /(.*)__(foxglove|webviz)_enum$/;
 
-// Foxglove Studio enum annotations are of the form: "Foo__foxglove_enum" (notice double underscore)
+// Lichtblick enum annotations are of the form: "Foo__foxglove_enum" (notice double underscore)
 // This method returns type name from "Foo" or undefined name doesn't match this format
 export function extractTypeFromStudioEnumAnnotation(name: string): string | undefined {
   const match = extractTypeFromStudioEnumAnnotationRegex.exec(name);

--- a/packages/studio-desktop/README.md
+++ b/packages/studio-desktop/README.md
@@ -1,3 +1,3 @@
 # @foxglove/studio-desktop
 
-This is an internal package used for bundling the Foxbox desktop app. Its API is not considered public or stable.
+This is an internal package used for bundling the Lichtblick desktop app. Its API is not considered public or stable.

--- a/packages/studio-desktop/src/common/types.ts
+++ b/packages/studio-desktop/src/common/types.ts
@@ -91,7 +91,7 @@ interface Desktop {
   // Load the source code for an extension
   loadExtension: (id: string) => Promise<string>;
 
-  // Install a Foxglove Studio extension (.foxe file) locally. The extension id is returned
+  // Install a Lichtblick extension (.foxe file) locally. The extension id is returned
   installExtension: (foxeFileData: Uint8Array) => Promise<DesktopExtension>;
 
   // Uninstall an extension. Returns true if the extension was found and uninstalled, or false if it

--- a/packages/studio-desktop/src/electronBuilderConfig.js
+++ b/packages/studio-desktop/src/electronBuilderConfig.js
@@ -48,7 +48,7 @@ function makeElectronBuilderConfig(params) {
         },
         {
           ext: "foxe",
-          name: "Lichtblicklick Extension",
+          name: "Lichtblick Extension",
           mimeType: "application/zip",
         },
       ],
@@ -125,7 +125,7 @@ function makeElectronBuilderConfig(params) {
           {
             CFBundleTypeExtensions: ["foxe"],
             CFBundleTypeIconFile: "FoxeIcon",
-            CFBundleTypeName: "Lichtblicklick Extension File",
+            CFBundleTypeName: "Lichtblick Extension File",
             CFBundleTypeRole: "Viewer",
             LSHandlerRank: "Owner",
             CFBundleTypeIconSystemGenerated: 1,
@@ -149,7 +149,7 @@ function makeElectronBuilderConfig(params) {
           },
           {
             UTTypeConformsTo: ["public.data", "public.archive", "public.zip-archive"],
-            UTTypeDescription: "Lichtblicklick Extension File",
+            UTTypeDescription: "Lichtblick Extension File",
             UTTypeIcons: { UTTypeIconText: "foxe" },
             UTTypeIdentifier: "dev.foxglove.extension",
             UTTypeTagSpecification: { "public.filename-extension": "foxe" },
@@ -171,7 +171,7 @@ function makeElectronBuilderConfig(params) {
     appx: {
       applicationId: "FoxgloveStudio",
       backgroundColor: "#f7def6",
-      displayName: "Lichtblicklick",
+      displayName: "Lichtblick",
       identityName: "Foxglove.Studio",
       publisher:
         "CN=Foxglove Technologies, O=Foxglove Technologies, L=San Francisco, S=California, C=US",

--- a/packages/studio-desktop/src/electronBuilderConfig.js
+++ b/packages/studio-desktop/src/electronBuilderConfig.js
@@ -48,7 +48,7 @@ function makeElectronBuilderConfig(params) {
         },
         {
           ext: "foxe",
-          name: "Foxbox Extension",
+          name: "Lichtblicklick Extension",
           mimeType: "application/zip",
         },
       ],
@@ -74,7 +74,7 @@ function makeElectronBuilderConfig(params) {
         },
         {
           ext: "foxe",
-          name: "Foxbox Extension",
+          name: "Lichtblicklick Extension",
           mimeType: "application/zip",
         },
       ],
@@ -125,7 +125,7 @@ function makeElectronBuilderConfig(params) {
           {
             CFBundleTypeExtensions: ["foxe"],
             CFBundleTypeIconFile: "FoxeIcon",
-            CFBundleTypeName: "Foxbox Extension File",
+            CFBundleTypeName: "Lichtblicklick Extension File",
             CFBundleTypeRole: "Viewer",
             LSHandlerRank: "Owner",
             CFBundleTypeIconSystemGenerated: 1,
@@ -149,7 +149,7 @@ function makeElectronBuilderConfig(params) {
           },
           {
             UTTypeConformsTo: ["public.data", "public.archive", "public.zip-archive"],
-            UTTypeDescription: "Foxbox Extension File",
+            UTTypeDescription: "Lichtblicklick Extension File",
             UTTypeIcons: { UTTypeIconText: "foxe" },
             UTTypeIdentifier: "dev.foxglove.extension",
             UTTypeTagSpecification: { "public.filename-extension": "foxe" },
@@ -171,7 +171,7 @@ function makeElectronBuilderConfig(params) {
     appx: {
       applicationId: "FoxgloveStudio",
       backgroundColor: "#f7def6",
-      displayName: "Foxbox",
+      displayName: "Lichtblicklick",
       identityName: "Foxglove.Studio",
       publisher:
         "CN=Foxglove Technologies, O=Foxglove Technologies, L=San Francisco, S=California, C=US",

--- a/packages/studio-desktop/src/electronBuilderConfig.js
+++ b/packages/studio-desktop/src/electronBuilderConfig.js
@@ -74,7 +74,7 @@ function makeElectronBuilderConfig(params) {
         },
         {
           ext: "foxe",
-          name: "Lichtblicklick Extension",
+          name: "Lichtblick Extension",
           mimeType: "application/zip",
         },
       ],

--- a/packages/studio-desktop/src/main/StudioAppUpdater.ts
+++ b/packages/studio-desktop/src/main/StudioAppUpdater.ts
@@ -68,7 +68,7 @@ class StudioAppUpdater extends EventEmitter<EventTypes> {
     };
     const onNotAvailable = (info: UpdateInfo) => {
       void dialog.showMessageBox({
-        message: `Foxbox is up to date (version ${info.version}).`,
+        message: `Lichtblick is up to date (version ${info.version}).`,
       });
     };
     const onError = (error: Error) => {

--- a/packages/studio-desktop/src/main/StudioWindow.ts
+++ b/packages/studio-desktop/src/main/StudioWindow.ts
@@ -455,7 +455,7 @@ class StudioWindow {
     const newMenu = buildMenu(browserWindow);
     const id = browserWindow.webContents.id;
 
-    log.info(`New Foxbox window ${id}`);
+    log.info(`New Lichtblick window ${id}`);
     StudioWindow.#windowsByContentId.set(id, this);
 
     browserWindow.once("closed", () => {

--- a/packages/studio-desktop/src/main/StudioWindow.ts
+++ b/packages/studio-desktop/src/main/StudioWindow.ts
@@ -24,11 +24,12 @@ import { APP_BAR_HEIGHT } from "@foxglove/studio-base/src/components/AppBar/cons
 import { NativeAppMenuEvent } from "@foxglove/studio-base/src/context/NativeAppMenuContext";
 import { palette } from "@foxglove/theme";
 
-import { encodeRendererArg } from "../common/rendererArgs";
 import StudioAppUpdater from "./StudioAppUpdater";
 import getDevModeIcon from "./getDevModeIcon";
 import { simulateUserClick } from "./simulateUserClick";
 import { getTelemetrySettings } from "./telemetry";
+import { encodeRendererArg } from "../common/rendererArgs";
+import { FOXGLOVE_PRODUCT_NAME } from "../common/webpackDefines";
 
 declare const MAIN_WINDOW_WEBPACK_ENTRY: string;
 

--- a/packages/studio-desktop/src/main/StudioWindow.ts
+++ b/packages/studio-desktop/src/main/StudioWindow.ts
@@ -24,12 +24,11 @@ import { APP_BAR_HEIGHT } from "@foxglove/studio-base/src/components/AppBar/cons
 import { NativeAppMenuEvent } from "@foxglove/studio-base/src/context/NativeAppMenuContext";
 import { palette } from "@foxglove/theme";
 
+import { encodeRendererArg } from "../common/rendererArgs";
 import StudioAppUpdater from "./StudioAppUpdater";
 import getDevModeIcon from "./getDevModeIcon";
 import { simulateUserClick } from "./simulateUserClick";
 import { getTelemetrySettings } from "./telemetry";
-import { encodeRendererArg } from "../common/rendererArgs";
-import { FOXGLOVE_PRODUCT_NAME } from "../common/webpackDefines";
 
 declare const MAIN_WINDOW_WEBPACK_ENTRY: string;
 
@@ -360,12 +359,6 @@ function buildMenu(browserWindow: BrowserWindow): Menu {
         label: t("appBar:about"),
         click: () => {
           sendNativeAppMenuEvent("open-help-about", browserWindow);
-        },
-      },
-      {
-        label: t("appBar:viewOurDocs"),
-        click: () => {
-          sendNativeAppMenuEvent("open-help-docs", browserWindow);
         },
       },
       { type: "separator" },

--- a/packages/studio-web/README.md
+++ b/packages/studio-web/README.md
@@ -1,3 +1,3 @@
 # @foxglove/studio-web
 
-This is an internal package used for bundling the Foxbox web app. Its API is not considered public or stable.
+This is an internal package used for bundling the Lichtblick web app. Its API is not considered public or stable.

--- a/packages/studio-web/src/CompatibilityBanner.tsx
+++ b/packages/studio-web/src/CompatibilityBanner.tsx
@@ -2,14 +2,14 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { Warning24Filled, Dismiss20Filled } from "@fluentui/react-icons";
+import { Dismiss20Filled, Warning24Filled } from "@fluentui/react-icons";
 import {
-  IconButton,
-  Typography,
-  Link,
   Button,
+  IconButton,
+  Link,
   ThemeProvider as MuiThemeProvider,
   Portal,
+  Typography,
 } from "@mui/material";
 import { useState } from "react";
 import { makeStyles } from "tss-react/mui";
@@ -100,7 +100,7 @@ function CompatibilityBannerBase({
 
         <div>
           <Typography variant="subtitle2">
-            {prompt} Foxbox currently requires Chrome v{MINIMUM_CHROME_VERSION}+.
+            {prompt} Lichtblick currently requires Chrome v{MINIMUM_CHROME_VERSION}+.
           </Typography>
 
           {!isChrome && (

--- a/packages/studio-web/src/webpackConfigs.ts
+++ b/packages/studio-web/src/webpackConfigs.ts
@@ -180,7 +180,7 @@ export const mainConfig =
   </html>
   `,
           foxgloveExtraHeadTags: `
-            <title>Foxbox</title>
+            <title>Lichtblick</title>
             <link rel="apple-touch-icon" sizes="180x180" href="apple-touch-icon.png" />
             <link rel="icon" type="image/png" sizes="32x32" href="favicon-32x32.png" />
             <link rel="icon" type="image/png" sizes="16x16" href="favicon-16x16.png" />

--- a/packages/studio/README.md
+++ b/packages/studio/README.md
@@ -1,5 +1,3 @@
 # Lichtblick Extension API
 
-This package contains type definitions for writing [Lichtblick](https://foxglove.dev/) extensions.
-
-See https://docs.foxglove.dev/docs/visualization/extensions/introduction
+This package contains type definitions for writing Lichtblick extensions.

--- a/packages/studio/README.md
+++ b/packages/studio/README.md
@@ -1,5 +1,5 @@
-# Foxbox Extension API
+# Lichtblick Extension API
 
-This package contains type definitions for writing [Foxbox](https://foxglove.dev/) extensions.
+This package contains type definitions for writing [Lichtblick](https://foxglove.dev/) extensions.
 
 See https://docs.foxglove.dev/docs/visualization/extensions/introduction

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -7,8 +7,8 @@
     "url": "https://github.com/foxglove/studio/tree/main/packages/studio"
   },
   "author": {
-    "name": "Foxglove Technologies",
-    "email": "support@foxglove.dev"
+    "name": "Lichtblick",
+    "email": "lichtblick@bmwgroup.com"
   },
   "homepage": "https://foxglove.dev/",
   "main": "./src/index.ts",

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@foxglove/studio",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "license": "MPL-2.0",
   "repository": {
     "type": "git",

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -4,13 +4,13 @@
   "license": "MPL-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/foxglove/studio/tree/main/packages/studio"
+    "url": "https://github.com/bmw-software-engineering/lichtblick/tree/main/packages/studio"
   },
   "author": {
     "name": "Lichtblick",
     "email": "lichtblick@bmwgroup.com"
   },
-  "homepage": "https://foxglove.dev/",
+  "homepage": "https://github.com/bmw-software-engineering",
   "main": "./src/index.ts",
   "files": [
     "src"

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -10,7 +10,7 @@
     "name": "Lichtblick",
     "email": "lichtblick@bmwgroup.com"
   },
-  "homepage": "https://foxglove.dev/",
+  "homepage": "https://github.com/bmw-software-engineering",
   "main": "./src/index",
   "devDependencies": {
     "@emotion/react": "11.13.0",

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "repository": {
     "type": "git",
-    "url": "https://github.com/foxglove/studio.git"
+    "url": "https://github.com/bmw-software-engineering/lichtblick.git"
   },
   "author": {
     "name": "Foxglove Technologies",

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -7,8 +7,8 @@
     "url": "https://github.com/bmw-software-engineering/lichtblick.git"
   },
   "author": {
-    "name": "Foxglove Technologies",
-    "email": "support@foxglove.dev"
+    "name": "Lichtblick",
+    "email": "lichtblick@bmwgroup.com"
   },
   "homepage": "https://foxglove.dev/",
   "main": "./src/index",

--- a/packages/theme/src/i18n/README.md
+++ b/packages/theme/src/i18n/README.md
@@ -1,3 +1,3 @@
-This directory contains localized strings for languages supported by Foxbox.
+This directory contains localized strings for languages supported by Lichtblick.
 
 To learn more about localization, see [CONTRIBUTING.md](../../../../CONTRIBUTING.md#localization).

--- a/packages/theme/src/i18n/en/appBar.ts
+++ b/packages/theme/src/i18n/en/appBar.ts
@@ -5,7 +5,6 @@
 export const appBar = {
   about: "About",
   addPanel: "Add panel",
-  documentation: "Documentation",
   exploreSampleData: "Explore sample data",
   exportLayoutToFile: "Export layout to file…",
   extensions: "Extensions",
@@ -30,6 +29,5 @@ export const appBar = {
   userProfile: "User profile",
   view: "View",
   viewData: "View data",
-  viewOurDocs: "View our docs",
   profile: "Profile",
 };

--- a/packages/theme/src/i18n/en/appSettings.ts
+++ b/packages/theme/src/i18n/en/appSettings.ts
@@ -8,7 +8,7 @@ export const appSettings = {
   askEachTime: "Ask each time",
   colorScheme: "Color scheme",
   dark: "Dark",
-  debugModeDescription: "Enable panels and features for debugging Foxbox",
+  debugModeDescription: "Enable panels and features for debugging Lichtblick",
   desktopApp: "Desktop app",
   displayTimestampsIn: "Display timestamps in",
   experimentalFeatures: "Experimental features",

--- a/packages/theme/src/i18n/en/general.ts
+++ b/packages/theme/src/i18n/en/general.ts
@@ -4,7 +4,7 @@
 
 // Generic global translation
 export const general = {
-  foxglove: "Foxglove",
+  lichtblick: "Lichtblick",
   learnMore: "Learn more",
   on: "On",
   off: "Off",

--- a/packages/theme/src/i18n/en/incompatibleLayoutVersion.ts
+++ b/packages/theme/src/i18n/en/incompatibleLayoutVersion.ts
@@ -4,7 +4,7 @@
 
 export const incompatibleLayoutVersion = {
   desktopText:
-    "This layout was created with a newer version of Foxbox. Please update to the latest version at ",
+    "This layout was created with a newer version of Lichtblick. Please update to the latest version at ",
   title: "Incompatible layout version",
   webText: "This layout was created with a newer version of Fobox. Please refresh your browser.",
 };

--- a/packages/theme/src/i18n/en/openDialog.ts
+++ b/packages/theme/src/i18n/en/openDialog.ts
@@ -32,5 +32,4 @@ export const openDialog = {
   startCollaboratingDescription:
     "Make the most of your Lichtblick account – whether you want to dive deep on your data or share tools with your teammates.",
   uploadToDataPlatform: "Upload to Data Platform",
-  viewOurDocs: "View our docs",
 };

--- a/packages/theme/src/i18n/en/openDialog.ts
+++ b/packages/theme/src/i18n/en/openDialog.ts
@@ -4,16 +4,16 @@
 
 export const openDialog = {
   canBeShared: "Share data files, visualization layouts, and custom extensions with teammates",
-  collaborateTitle: "Accelerate development with Foxglove",
+  collaborateTitle: "Accelerate development with Lichtblick",
   convenientWebInterface:
     "Use a convenient web interface to tag, search, and retrieve data at lightning speed",
   createAFreeAccount: "Create a free account",
   exploreSampleData: "Explore sample data",
   learnMore: "Learn more",
   needHelp: "Need help?",
-  needHelpDescription: "View our documentation, or check out the tutorials on the Foxglove blog.",
-  newToFoxgloveStudio: "New to Foxglove?",
-  newToFoxgloveStudioDescription:
+  needHelpDescription: "View our documentation, or check out the tutorials on the Lichtblick blog.",
+  newToLichtblickStudio: "New to Lichtblick?",
+  newToLichtblickStudioDescription:
     "Start by exploring a sample dataset or checking out our documentation.",
   openAGitHubIssue: "Open a GitHub issue",
   openConnection: "Open connection",
@@ -22,15 +22,15 @@ export const openDialog = {
   openLocalFile: "Open local file",
   openLocalFileDescription: "Visualize data directly from your local filesystem.",
   openUrl: "Upload and share data",
-  openUrlDescription: "Use Foxglove to share data with your team.",
+  openUrlDescription: "Use Lichtblick to share data with your team.",
   recentDataSources: "Recent data sources",
   secureStorageOfData: "Securely store petabytes of ROS or custom data",
   seeTutorials: "See tutorials",
   shareLayouts: "Share layouts",
   signIn: "Sign in",
-  startCollaborating: "Start collaborating with your Foxglove organization",
+  startCollaborating: "Start collaborating with your Lichtblick organization",
   startCollaboratingDescription:
-    "Make the most of your Foxglove account – whether you want to dive deep on your data or share tools with your teammates.",
+    "Make the most of your Lichtblick account – whether you want to dive deep on your data or share tools with your teammates.",
   uploadToDataPlatform: "Upload to Data Platform",
   viewOurDocs: "View our docs",
 };

--- a/packages/theme/src/i18n/en/openDialog.ts
+++ b/packages/theme/src/i18n/en/openDialog.ts
@@ -12,8 +12,8 @@ export const openDialog = {
   learnMore: "Learn more",
   needHelp: "Need help?",
   needHelpDescription: "View our documentation, or check out the tutorials on the Lichtblick blog.",
-  newToLichtblickStudio: "New to Lichtblick?",
-  newToLichtblickStudioDescription:
+  newToLichtblick: "New to Lichtblick?",
+  newToLichtblickDescription:
     "Start by exploring a sample dataset or checking out our documentation.",
   openAGitHubIssue: "Open a GitHub issue",
   openConnection: "Open connection",

--- a/packages/typescript-transformers/package.json
+++ b/packages/typescript-transformers/package.json
@@ -7,8 +7,8 @@
     "url": "https://github.com/bmw-software-engineering/lichtblick.git"
   },
   "author": {
-    "name": "Foxglove Technologies",
-    "email": "support@foxglove.dev"
+    "name": "Lichtblick",
+    "email": "lichtblick@bmwgroup.com"
   },
   "homepage": "https://foxglove.dev/",
   "main": "./src/index.ts",

--- a/packages/typescript-transformers/package.json
+++ b/packages/typescript-transformers/package.json
@@ -10,7 +10,7 @@
     "name": "Lichtblick",
     "email": "lichtblick@bmwgroup.com"
   },
-  "homepage": "https://foxglove.dev/",
+  "homepage": "https://github.com/bmw-software-engineering",
   "main": "./src/index.ts",
   "files": [
     "dist",

--- a/packages/typescript-transformers/package.json
+++ b/packages/typescript-transformers/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "repository": {
     "type": "git",
-    "url": "https://github.com/foxglove/studio.git"
+    "url": "https://github.com/bmw-software-engineering/lichtblick.git"
   },
   "author": {
     "name": "Foxglove Technologies",

--- a/web/README.md
+++ b/web/README.md
@@ -1,1 +1,1 @@
-This is an internal package used for bundling the Foxbox web app. Its API is not considered public or stable.
+This is an internal package used for bundling the Lichtblick web app. Its API is not considered public or stable.

--- a/yarn.lock
+++ b/yarn.lock
@@ -13128,78 +13128,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"foxbox@workspace:.":
-  version: 0.0.0-use.local
-  resolution: "foxbox@workspace:."
-  dependencies:
-    "@actions/core": 1.10.1
-    "@actions/exec": 1.1.1
-    "@actions/tool-cache": 2.0.1
-    "@babel/core": 7.24.9
-    "@babel/plugin-proposal-decorators": 7.24.7
-    "@babel/plugin-proposal-explicit-resource-management": 7.24.7
-    "@babel/preset-env": 7.24.8
-    "@babel/preset-typescript": 7.24.7
-    "@foxglove/eslint-plugin": 1.0.0
-    "@foxglove/eslint-plugin-studio": "workspace:*"
-    "@foxglove/hooks": "workspace:*"
-    "@foxglove/log": "workspace:*"
-    "@foxglove/studio": "workspace:*"
-    "@foxglove/tsconfig": 2.0.0
-    "@mui/material": 5.13.5
-    "@octokit/rest": 20.0.2
-    "@storybook/addon-actions": 7.6.10
-    "@storybook/addon-essentials": 7.6.10
-    "@storybook/addon-interactions": 7.6.10
-    "@storybook/react": 7.6.10
-    "@storybook/react-webpack5": 7.6.10
-    "@types/babel__core": ^7.20.3
-    "@types/babel__preset-env": ^7.9.6
-    "@types/case-sensitive-paths-webpack-plugin": 2.1.9
-    "@types/jest": 29.5.11
-    "@types/license-checker": ^25.0.6
-    "@types/semver": ^7.5.3
-    "@typescript-eslint/eslint-plugin": 6.10.0
-    "@typescript-eslint/parser": 6.10.0
-    babel-plugin-transform-import-meta: 2.2.1
-    cross-env: 7.0.3
-    depcheck: 1.4.7
-    electron: 25.8.4
-    electron-builder: 24.13.3
-    eslint: 8.50.0
-    eslint-config-prettier: 9.1.0
-    eslint-import-resolver-webpack: 0.13.8
-    eslint-plugin-es: 4.1.0
-    eslint-plugin-file-progress: 1.3.0
-    eslint-plugin-filenames: 1.3.2
-    eslint-plugin-import: 2.28.1
-    eslint-plugin-jest: 27.6.3
-    eslint-plugin-prettier: 5.1.3
-    eslint-plugin-react: 7.33.2
-    eslint-plugin-react-hooks: 4.6.0
-    eslint-plugin-storybook: 0.6.15
-    eslint-plugin-tss-unused-classes: 1.0.2
-    jest: 29.7.0
-    jest-environment-jsdom: 29.7.0
-    license-checker: 25.0.1
-    prettier: 3.3.2
-    react-use: 17.5.1
-    rehype-raw: 6.1.1
-    rimraf: 5.0.5
-    semver: 7.5.4
-    storybook: 7.6.20
-    ts-node: 10.9.2
-    ts-unused-exports: 10.0.1
-    tslib: 2.6.2
-    typescript: 5.3.3
-    vm-browserify: 1.1.2
-    webpack: 5.93.0
-    webpack-cli: 5.1.4
-    webpack-dev-server: 5.0.4
-    webpack-hot-middleware: 2.26.0
-  languageName: unknown
-  linkType: soft
-
 "fraction.js@npm:4.3.4":
   version: 4.3.4
   resolution: "fraction.js@npm:4.3.4"
@@ -16303,6 +16231,78 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lichtblick@workspace:.":
+  version: 0.0.0-use.local
+  resolution: "lichtblick@workspace:."
+  dependencies:
+    "@actions/core": 1.10.1
+    "@actions/exec": 1.1.1
+    "@actions/tool-cache": 2.0.1
+    "@babel/core": 7.24.9
+    "@babel/plugin-proposal-decorators": 7.24.7
+    "@babel/plugin-proposal-explicit-resource-management": 7.24.7
+    "@babel/preset-env": 7.24.8
+    "@babel/preset-typescript": 7.24.7
+    "@foxglove/eslint-plugin": 1.0.0
+    "@foxglove/eslint-plugin-studio": "workspace:*"
+    "@foxglove/hooks": "workspace:*"
+    "@foxglove/log": "workspace:*"
+    "@foxglove/studio": "workspace:*"
+    "@foxglove/tsconfig": 2.0.0
+    "@mui/material": 5.13.5
+    "@octokit/rest": 20.0.2
+    "@storybook/addon-actions": 7.6.10
+    "@storybook/addon-essentials": 7.6.10
+    "@storybook/addon-interactions": 7.6.10
+    "@storybook/react": 7.6.10
+    "@storybook/react-webpack5": 7.6.10
+    "@types/babel__core": ^7.20.3
+    "@types/babel__preset-env": ^7.9.6
+    "@types/case-sensitive-paths-webpack-plugin": 2.1.9
+    "@types/jest": 29.5.11
+    "@types/license-checker": ^25.0.6
+    "@types/semver": ^7.5.3
+    "@typescript-eslint/eslint-plugin": 6.10.0
+    "@typescript-eslint/parser": 6.10.0
+    babel-plugin-transform-import-meta: 2.2.1
+    cross-env: 7.0.3
+    depcheck: 1.4.7
+    electron: 25.8.4
+    electron-builder: 24.13.3
+    eslint: 8.50.0
+    eslint-config-prettier: 9.1.0
+    eslint-import-resolver-webpack: 0.13.8
+    eslint-plugin-es: 4.1.0
+    eslint-plugin-file-progress: 1.3.0
+    eslint-plugin-filenames: 1.3.2
+    eslint-plugin-import: 2.28.1
+    eslint-plugin-jest: 27.6.3
+    eslint-plugin-prettier: 5.1.3
+    eslint-plugin-react: 7.33.2
+    eslint-plugin-react-hooks: 4.6.0
+    eslint-plugin-storybook: 0.6.15
+    eslint-plugin-tss-unused-classes: 1.0.2
+    jest: 29.7.0
+    jest-environment-jsdom: 29.7.0
+    license-checker: 25.0.1
+    prettier: 3.3.2
+    react-use: 17.5.1
+    rehype-raw: 6.1.1
+    rimraf: 5.0.5
+    semver: 7.5.4
+    storybook: 7.6.20
+    ts-node: 10.9.2
+    ts-unused-exports: 10.0.1
+    tslib: 2.6.2
+    typescript: 5.3.3
+    vm-browserify: 1.1.2
+    webpack: 5.93.0
+    webpack-cli: 5.1.4
+    webpack-dev-server: 5.0.4
+    webpack-hot-middleware: 2.26.0
+  languageName: unknown
+  linkType: soft
+
 "lie@npm:~3.3.0":
   version: 3.3.0
   resolution: "lie@npm:3.3.0"
@@ -19302,9 +19302,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-dnd@patch:react-dnd@npm:16.0.1#./patches/react-dnd.patch::locator=foxbox%40workspace%3A.":
+"react-dnd@patch:react-dnd@npm:16.0.1#./patches/react-dnd.patch::locator=lichtblick%40workspace%3A.":
   version: 16.0.1
-  resolution: "react-dnd@patch:react-dnd@npm%3A16.0.1#./patches/react-dnd.patch::version=16.0.1&hash=7ebec9&locator=foxbox%40workspace%3A."
+  resolution: "react-dnd@patch:react-dnd@npm%3A16.0.1#./patches/react-dnd.patch::version=16.0.1&hash=7ebec9&locator=lichtblick%40workspace%3A."
   dependencies:
     "@react-dnd/invariant": ^4.0.1
     "@react-dnd/shallowequal": ^4.0.1
@@ -19692,9 +19692,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-use@patch:react-use@17.4.0#./patches/react-use.patch::locator=foxbox%40workspace%3A.":
+"react-use@patch:react-use@17.4.0#./patches/react-use.patch::locator=lichtblick%40workspace%3A.":
   version: 17.4.0
-  resolution: "react-use@patch:react-use@npm%3A17.4.0#./patches/react-use.patch::version=17.4.0&hash=16b4d0&locator=foxbox%40workspace%3A."
+  resolution: "react-use@patch:react-use@npm%3A17.4.0#./patches/react-use.patch::version=17.4.0&hash=16b4d0&locator=lichtblick%40workspace%3A."
   dependencies:
     "@types/js-cookie": ^2.2.6
     "@xobotyi/scrollbar-width": ^1.9.5


### PR DESCRIPTION
**User-Facing Changes**

Renames Foxbox to Lichtblick and removes some old links related to documentation of the tool.

**Description**
Since we have a new name, this PR aims to rename Foxbox to Lichtblick when it's visible to the user. We are also renaming places that mentions Foxglove Studio and it's documentation.

**Checklist**

- [x] The web version was tested and it is running ok
- [x] The desktop version was tested and it is running ok
- [x] I've updated/created the storybook file(s)
- [x] The release version was updated on package.json files
