### PR TITLE
Cicd/replace pat with GitHub token

### DIFF
--- a/.github/workflows/cloudflare-pages.yml
+++ b/.github/workflows/cloudflare-pages.yml
@@ -40,7 +40,7 @@ jobs:
         with:
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          gitHubToken: ${{ secrets.FOXGLOVEBOT_GITHUB_TOKEN }}
+          gitHubToken: ${{ github.token }}
           branch: ${{ github.head_ref || github.ref_name }}
           projectName: foxglove-studio-oss
           directory: web/.webpack

--- a/.github/workflows/dependabot-fix.yml
+++ b/.github/workflows/dependabot-fix.yml
@@ -27,10 +27,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4.1.1
         with:
-          # Using a Personal Access Token here is required to trigger workflows on our new commit.
-          # The default GitHub token doesn't trigger any workflows.
-          # See: https://github.community/t/push-from-action-does-not-trigger-subsequent-action/16854/2
-          token: ${{ secrets.LICHTBLICK_GITHUB_TOKEN }}
           ref: ${{ github.event.pull_request.head.ref }}
           lfs: true
 
@@ -59,7 +55,7 @@ jobs:
       - uses: octokit/request-action@v2.1.9
         if: contains(fromJSON('["opened", "reopened"]'), github.event.action)
         env:
-          GITHUB_TOKEN: ${{ secrets.LICHTBLICK_GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}
         with:
           route: POST /repos/{owner_and_repo}/pulls/{pull_number}/reviews
           owner_and_repo: ${{ github.repository }}
@@ -69,7 +65,7 @@ jobs:
       - uses: octokit/request-action@v2.1.9
         if: contains(fromJSON('["opened", "reopened"]'), github.event.action)
         env:
-          GITHUB_TOKEN: ${{ secrets.LICHTBLICK_GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}
         with:
           route: POST /repos/{owner_and_repo}/issues/{pull_number}/comments
           owner_and_repo: ${{ github.repository }}

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -41,7 +41,7 @@ jobs:
           base: main
           head: release/${{ github.event.release.tag_name }}
         env:
-          GITHUB_TOKEN: ${{ secrets.LICHTBLICK_GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}
 
   npm:
     name: Publish to NPM

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lichtblick",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "license": "MPL-2.0",
   "private": true,
   "productName": "Lichtblick",

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@foxglove/studio",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "license": "MPL-2.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
**User-Facing Changes**
Developers used to have a PAT to perform some actions, which is not ideal because the project can't depend on a user token.

**Description**
It was modified to use the GITHUB_TOKEN, which has all necessary permissions to perform all required actions.

Some useful links that were used to make this decision:
- https://github.com/marketplace/actions/checkout#push-a-commit-using-the-built-in-token
- https://github.com/octokit/auth-action.js#createactionauth
- https://github.com/cloudflare/pages-action
- https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token

**Checklist**

- [x] The web version was tested and it is running ok
- [x] The desktop version was tested and it is running ok
- [x] I've updated/created the storybook file(s)
- [x] The release version was updated on package.json files
